### PR TITLE
Impact about training events

### DIFF
--- a/content/about-us/impact.md
+++ b/content/about-us/impact.md
@@ -51,7 +51,7 @@ We value a culture of assessment and consistently assess learner outcomes from w
 
 ### Measuring the Impact of Our Workshops and Training
 
-We conduct pre- and post-workshop surveys for Carpentries Workshops & Instructor Training Events. Use the links below to preview the questions currently included in our surveys:
+We conduct pre- and post-workshop surveys for Carpentries Workshops & Training Events. Use the links below to preview the questions currently included in our surveys:
 
 ### The Carpentries Workshop Surveys
 


### PR DESCRIPTION
Recommendation from Toby in #138:   In "Measuring the impact of our workshops a training", adjust to refer to both Instructor Training and CLDT, i.e. "We conduct pre- and post-workshop surveys for Carpentries Workshops & Training Events." We cannot provide a preview of the pre- and post-training surveys for CLDT just yet, but I plan to migrate it into TypeForm soon.

