### PR TITLE
DNM: Add accessibility statement across multiple pages

### DIFF
--- a/content/community/events.md
+++ b/content/community/events.md
@@ -24,3 +24,7 @@ frame.scrolling = 'no';
 frame.src = 'https://calendar.google.com/calendar/embed?title=The%20Carpentries%20Community%20Calendar%20&mode=WEEK&src=oseuuoht0tvjbokgg3noh8c47g%40group.calendar.google.com&color=%237FB3D5&src=c_tmtrkf328gjtcs1u05mhfbn7qc%40group.calendar.google.com&color=%23BE6D00&ctz=' + timezone.name();
 document.getElementById('calendar').appendChild(frame);
 </script>
+
+## Diversity, Equity, and Inclusion Statement
+
+{{< accessibility >}}

--- a/content/community/get-involved.md
+++ b/content/community/get-involved.md
@@ -118,3 +118,6 @@ CarpentryConnects are community convenings, organised to bring together communit
 
 Here is a list of all CarpentryConnect events held in the past: [carpentryconnect.org/case-studies/](https://carpentryconnect.org/case-studies/)
 
+## Diversity, Equity, and Inclusion Statement
+
+{{< accessibility >}}

--- a/content/workshops/_index.md
+++ b/content/workshops/_index.md
@@ -44,6 +44,11 @@ There are many options for you to choose from! To help you decide which Lesson P
 [Request a workshop]({{< param amy_workshop_landing >}})
 {.button}
 
+## Diversity, Equity, and Inclusion Statement
+
+{{< accessibility >}}
+
 ## Contact 
 
 Have Questions? Please consult our [Workshops FAQ](/workshops/workshops-faq) or contact our team at [{{< param workshops_email >}}](mailto:{{< param workshops_email >}}).
+

--- a/layouts/shortcodes/accessibility.html
+++ b/layouts/shortcodes/accessibility.html
@@ -1,0 +1,20 @@
+
+
+<h3>Our Community is Our Strength</h3>
+<p>At The Carpentries, we are committed to building a diverse, equitable, and inclusive community that values all individuals and their unique identities. We prioritise accessibility and inclusivity in our curricula and programs and value transparency, fairness, and honesty to build trust within our community. Building an inclusive community is an ongoing process that requires consistent effort and commitment, and we strive for continuous improvement.</p>
+
+<h3>Accessibility Statement</h3>
+<p>The Carpentries is committed to providing inclusive and accessible content that enables all individuals, including those with disabilities, to participate and engage fully. We are actively working to increase the accessibility and usability of Carpentries’ content and in doing so adhere to many of the available standards and guidelines including those from the World Wide Web Consortium.</p>
+
+<p>If there are any aspects of our community including the website, community discussions, instruction, or the design of our lessons that result in barriers to your inclusion, please <a href="mailto:team@carpentries.org">email us</a> with as much information as possible including the name, location, and date of the event you attended, or any relevant links that provide context (e.g. Slack, GitHub).</p>
+
+<h3>Request an accommodation</h3>
+
+<p>At The Carpentries, we are committed to building a diverse, equitable, and inclusive community that values all individuals and their unique identities. We prioritise accessibility and inclusivity in our curricula and programs and value transparency, fairness, and honesty to build trust within our community. Building an inclusive community is an ongoing process that requires consistent effort and commitment, and we strive for continuous improvement.</p>
+
+<p>To request an accommodation for a Carpentries event, please fill out the <a href="https://carpentries.typeform.com/to/B2OSYaD0">accommodation request form</a>.</p>
+
+If you have questions or need assistance with the accommodation form please <a href="mailto:team@carpentries.org">email us</a>.
+
+<h3>Resources</h3>
+<p><a href="https://zenodo.org/records/10391883">The Toolkit of IDEAS</a> (Inclusion, Diversity, Equity and Accessibility Strategies) is a practical resource for Carpentries’ Instructors, helpers, and workshop hosts. We know that many people care about inclusion, diversity, equity and accessibility but are not sure how it connects to teaching foundational coding and data science skills. This toolkit aims to bridge this gap. This is version 1, which means it is a starting point and not a fully comprehensive resource. The hope is that the Core Team and community members will continue to update and extend this resource over time.</p>


### PR DESCRIPTION
As suggested by #183, this PR adds the accessibility statement on the workshops, get involved, and events calendar pages.