### PR TITLE
Update language and links in Workshops FAQ

### DIFF
--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -78,7 +78,7 @@ If you are scheduled to teach a Carpentries workshop and the host cancels, you w
 
 ### How soon can I request a Carpentries workshop?
 
-The Carpentries workshops are offered on-demand, not on a set schedule. We ask for a minimum of two to three months lead time to organise the workshop. If a request is less than two months, there will be no guarantee that we will be able to provide Instructors for your workshop. Please be advised that a workshop will not be scheduled until it has been confirmed by the host and The Carpentries Workshop Administrator. Our workshops are organised based on the order the Workshop Request Form is received and finalized. 
+The Carpentries workshops are offered on-demand, not on a set schedule. We ask for a minimum of two to three months lead time to organise the workshop. If a request is less than two months, there will be no guarantee that we will be able to provide Instructors for your workshop. Please be advised that a workshop will not be scheduled until it has been confirmed by the host and The Carpentries Workshop Administrator. Our workshops are organised based on the order the Workshop Request Form is received and finalised. 
 
 
 ### My currency is not USD, will I get invoiced in USD or my local currency?
@@ -122,7 +122,7 @@ Your workshop does not have to be two full days. You are encouraged to conduct y
 
 Self-Organised workshops are managed by the instructor/organiser, who is responsible for taking care of all the logistics. This means you will be responsible for providing your own Zoom room for conducting workshops. Please be sure to review our [Recommendations for Teaching Carpentries Workshops Online](/online-workshop-recommendations/).
 
-For Centrally-Organised workshops, if your institution has a videoconferencing platform available, we recommend that you use that same platform for The Carpentries workshop. This will reduce the time needed for workshop organizers and learners to learn a new system. However, if you do not have access to a video conferencing system, we will be able to provide you with access to one of our Zoom rooms.
+For Centrally-Organised workshops, if your institution has a videoconferencing platform available, we recommend that you use that same platform for The Carpentries workshop. This will reduce the time needed for workshop organisers and learners to learn a new system. However, if you do not have access to a video conferencing system, we will be able to provide you with access to one of our Zoom rooms.
 
 ### How many Instructors are needed to teach the workshop?
 
@@ -155,7 +155,7 @@ A Self-Organised workshop is organised by the workshop instructor/organiser. Thi
 
 ### How do I get survey data/links for previous workshops?
 
-The Workshops and Instruction Team can provide survey result links for past workshops (August 2018 - present) to workshop instructors/organizers or instructors affiliated with the hosting organisation. To request survey results links, please send an email to the Workshops and Instruction Team (via [{{< param workshops_email >}}](mailto:{{< param workshops_email >}})) with your request and include a link to the workshop website(s) and/or slug(s).
+The Workshops and Instruction Team can provide survey result links for past workshops (August 2018 - present) to workshop instructors/organisers or instructors affiliated with the hosting organisation. To request survey results links, please send an email to the Workshops and Instruction Team (via [{{< param workshops_email >}}](mailto:{{< param workshops_email >}})) with your request and include a link to the workshop website(s) and/or slug(s).
 
 ### Can we restrict who participates in our workshops?
 

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -64,13 +64,13 @@ Our Instructors are volunteers and are not paid for their time teaching. Therefo
 
 The details of how you will manage the Instructors’ travel is discussed once the Instructors are confirmed and introduced to the host. *The Carpentries is not involved in this process.*
 
-### Who can be a Helper and what do they contribute to the workshop?
+### Who can be a helper and what do they contribute to the workshop?
 
 Helpers are often recruited from the local community at the host site to support Carpentries workshops. Helpers support learners one-on-one if they are stuck installing software, understanding a certain line of code, or any other parts of the learning process. [Here]({{< param handbook_url >}}/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) is more information regarding helpers.
 
-### Are Helpers reimbursed for travel?
+### Are helpers reimbursed for travel?
 
-The Carpentries is not responsible for selecting Helpers. This is the responsibility of the host organisation. It is the discretion of the organisation if they would like to reimburse the helpers for travel. [Here]({{< param handbook_url >}}/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) is more information regarding helpers.
+The Carpentries is not responsible for selecting helpers. This is the responsibility of the host organisation. It is the discretion of the organisation if they would like to reimburse the helpers for travel. [Here]({{< param handbook_url >}}/topic_folders/hosts_instructors/hosts_instructors_checklist.html#helper-checklist) is more information regarding helpers.
 
 ### As an Instructor, will I still get credit for a workshop if the host cancelled?
 
@@ -95,9 +95,9 @@ Self-Organised workshops are managed by the instructor/organiser. Since you will
 
 When planning a Self-Organised workshop, we ask that you notify us of your planned workshop. Once the workshop webpage is created, please share the link with us and notify us of your planned workshop via the [Self-Organised workshop form]({{< param amy_workshop_landing >}}). Once we receive the link to the workshop webpage, we will be able to [add your workshop to our website](/upcoming_workshops/), provide support (in the form of survey result links and AMI instances for Genomics workshops), and get Instructors and helpers credit for the workshops they teach.
 
-### If I need help recruiting Instructors and/or Helpers for a Self-Organised workshop, what are my options?
+### If I need help recruiting Instructors and/or helpers for a Self-Organised workshop, what are my options?
 
-If you are organising a Self-Organised workshop, there are resources for you to recruit Instructors and/or Helpers. Below are the channels you can use:
+If you are organising a Self-Organised workshop, there are resources for you to recruit Instructors and/or helpers. Below are the channels you can use:
 
 * Any local or group specific mailing list on [TopicBox](https://carpentries.topicbox.com/groups)
 * Any local or group specific slack channel

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -74,7 +74,7 @@ The Carpentries is not responsible for selecting helpers. This is the responsibi
 
 ### As an Instructor, will I still get credit for a workshop if the host cancelled?
 
-If you are scheduled to teach a Carpentries workshop and the host cancels, you will still receive credit for the workshop. If a workshop is scheduled and you have to resign from teaching, you will not receive credit for the workshop.
+If you are scheduled to teach a Carpentries workshop and the host cancels, you will still receive credit for the workshop. If a workshop is scheduled and you have to withdraw from teaching, you will not receive credit for the workshop.
 
 ### How soon can I request a Carpentries workshop?
 
@@ -83,7 +83,7 @@ The Carpentries workshops are offered on-demand, not on a set schedule. We ask f
 
 ### My currency is not USD, will I get invoiced in USD or my local currency?
 
-If your organization does not accept invoices in USD, please let us know. The Workshops and Instruction Team will connect you with the Business Team, who will work with you in coordinating invoicing. To keep workshops accessible, The Carpentries will take responsibility for standard fees that arise due to an organisation’s location outside of the US. We see this as a good business practice within a global community.
+If your organization does not accept invoices in USD, please let us know. The Workshops and Instruction Team will connect you with the Management Team, who will work with you in coordinating invoicing. To keep workshops accessible, The Carpentries will take responsibility for standard fees that arise due to an organisation’s location outside of the US. We see this as a good business practice within a global community.
 
 ## Self-Organised Workshops
 
@@ -100,7 +100,7 @@ When planning a Self-Organised workshop, we ask that you notify us of your plann
 If you are organising a Self-Organised workshop, there are resources for you to recruit Instructors and/or helpers. Below are the channels you can use:
 
 * Any local or group specific mailing list on [TopicBox](https://carpentries.topicbox.com/groups)
-* Any local or group specific slack channel
+* Any local or group specific Slack channel
 
 These channels were designed specifically for community members to communicate about specific needs and to build local capacity.  Recruiting done in any other channel will be removed.
 
@@ -131,7 +131,7 @@ Teaching online is a challenge. We recommend a minimum of two Instructors and a 
 
 ### What are the roles of everyone participating in a workshop?
 
-*Instructor*: A person who has been certified by The Carpentries and understands best practices as outlined by The Carpentries Curricula. These persons will lead the workshop and teach the scheduled lessons.
+*Instructor*: A person who has been certified by The Carpentries and understands best practices as outlined by The Carpentries curricula. These persons will lead the workshop and teach the scheduled lessons.
 
 *Helper*: A person who is familiar with the topics being taught at a workshop. They support learners one-on-one if they are stuck installing software, understanding a certain line of code, or any other parts of the learning process.
 
@@ -184,4 +184,4 @@ The Instructors selected to teach workshops are volunteers and are not paid for 
 
 ## Further Resources
 
-See our [Membership FAQ page](/member_faq/) for frequently asked questions specifically relevant to Carpentries Member Organisations.
+Visit our [Membership FAQ page](/member_faq/) for frequently asked questions specifically relevant to Carpentries Member Organisations.

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -56,7 +56,7 @@ To be considered an official Carpentries workshop, you must follow the [Core Cur
 
 ### How much does a workshop cost?
 
-Please visit our [website](/workshops/#workshop-cost) for more information.
+Please visit our [pricing page](/support/pricing) for more information.
 
 ### Do Instructors pay for travel?
 

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -10,11 +10,11 @@ cascade:
 
 ### Why is my workshop not listed on the carpentries.org webpage?
 
-There are 3 things that must happen in order for a workshop to appear on The Carpentries webpage. You must complete the [workshop request/notification form]({{< param amy_workshop_landing >}}), the workshop website must include the venue, and at least one Instructor must be identified. If the Instructors change, we will get notified and will be able to make the update.
+There are three things that must happen in order for a workshop to appear on The Carpentries webpage. You must complete the [workshop request/notification form]({{< param amy_workshop_landing >}}), the workshop website must include the venue, and at least one Instructor must be identified. If the Instructors change, we will get notified and will be able to make the update.
 
 ### If I am teaching a Data Carpentry Genomics workshop, how many AWS Instances will be provided and when will we receive them?
 
-A member of the Workshops and Instruction Team will contact the Hosts/Instructors approximately 2-3 weeks prior to the workshop to find out how many instances are needed. You will be asked to provide the total number of Instructors, helpers and learners. Approximately 1 week prior to the workshop, the Workshops and Instruction Team will provide you with test instances for each Instructor and helper for testing/practice. Approximately 3 days before the workshop, you will be asked for your final attendance so we can send you the AWS instances for the workshop. On the day prior to the workshop, the Workshops and Instruction Team will provide you with instances for each Instructor, helper and learner for the workshop. We will also send a few extras for backup. The AWS Instances will be terminated the day after the workshop.  Please submit your workshop request/notification form at least 21 days in advance.
+A member of the Workshops and Instruction Team will contact the Hosts/Instructors approximately two to three weeks prior to the workshop to find out how many instances are needed. You will be asked to provide the total number of Instructors, helpers and learners. Approximately one week prior to the workshop, the Workshops and Instruction Team will provide you with test instances for each Instructor and helper for testing/practice. Approximately three days before the workshop, you will be asked for your final attendance so we can send you the AWS instances for the workshop. On the day prior to the workshop, the Workshops and Instruction Team will provide you with instances for each Instructor, helper and learner for the workshop. We will also send a few extras for backup. The AWS Instances will be terminated the day after the workshop.  Please submit your workshop request/notification form at least 21 days in advance.
 
 ### What is a slug? And how should I use it to name my workshop website?
 
@@ -38,7 +38,7 @@ The learner facing survey links are automatically generated on the workshop's we
 
 ### How do I access the survey results?
 
-If you are planning a workshop, please notify the Workshops and Instruction Team of your planned workshop using the [workshop request form]({{< param amy_workshop_landing >}}). The Workshops and Instruction Team will send the link to view results of the survey 1-2 weeks prior to the workshop. If there are more than 10 survey responses, you will have the option to download the survey data, using the "Download CSV" link at the bottom right of the survey results page.
+If you are planning a workshop, please notify the Workshops and Instruction Team of your planned workshop using the [workshop request form]({{< param amy_workshop_landing >}}). The Workshops and Instruction Team will send the link to view results of the survey one to two weeks prior to the workshop. If there are more than 10 survey responses, you will have the option to download the survey data, using the "Download CSV" link at the bottom right of the survey results page.
 
 ## Curriculum
 
@@ -78,7 +78,7 @@ If you are scheduled to teach a Carpentries workshop and the host cancels, you w
 
 ### How soon can I request a Carpentries workshop?
 
-The Carpentries workshops are offered on-demand, not on a set schedule. We ask for a minimum of 2-3 months lead time to organise the workshop. If a request is less than 2 months, there will be no guarantee that we will be able to provide Instructors for your workshop. Please be advised that a workshop will not be scheduled until it has been confirmed by the host and The Carpentries Workshop Administrator. Our workshops are organised based on the order the Workshop Request Form is received and finalized. 
+The Carpentries workshops are offered on-demand, not on a set schedule. We ask for a minimum of two to three months lead time to organise the workshop. If a request is less than two months, there will be no guarantee that we will be able to provide Instructors for your workshop. Please be advised that a workshop will not be scheduled until it has been confirmed by the host and The Carpentries Workshop Administrator. Our workshops are organised based on the order the Workshop Request Form is received and finalized. 
 
 
 ### My currency is not USD, will I get invoiced in USD or my local currency?
@@ -114,9 +114,9 @@ You can review the  [Recommendation for Teaching Carpentries Workshops Online](h
 
 We updated the [workshop website template](https://github.com/carpentries/workshop-template) to make it easier to indicate that a workshop will be taught online. Instructions to customise your workshop website are available on the [customisation page](https://carpentries.github.io/workshop-template/customization/index.html).
 
-### Does the workshop have to be 2 full days?
+### Does the workshop have to be two full days?
 
-Your workshop does not have to be 2 full days. You are encouraged to conduct your workshop over 4 half days if necessary. This is up to the discretion of the workshop organiser/Instructors and the needs of the audience.
+Your workshop does not have to be two full days. You are encouraged to conduct your workshop over four half days if necessary. This is up to the discretion of the workshop organiser/Instructors and the needs of the audience.
 
 ### Will I be provided with a Zoom room to run my online workshop?
 

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -46,11 +46,11 @@ If you are planning a workshop, please notify the Workshops and Instruction Team
 
 It is important that we know about workshops being publicised because people often contact us to report that they will be unable to attend a workshop or to ask questions and if we do not know about planned workshops, we can not provide support or share information with Instructors.
 
-If you are teaching a portion of The Carpentries curriculum or if the workshop does not align with the [Core Curriculum](/workshops/#workshop-core) we ask that you still [register]({{< param amy_workshop_landing >}}) your workshop and select the “Mix & Match” option for the question “Which Carpentries workshop are you teaching?”. *This option is only available for Self-Organised workshops. Centrally-Organised workshops are required to follow the Core Curricula.*
+If you are teaching a portion of The Carpentries curriculum or if the workshop does not align with the [Core Curriculum](/workshops/host-workshop/#curriculum-requirements-for-centrally-organised-workshops) we ask that you still [register]({{< param amy_workshop_landing >}}) your workshop and select the “Mix & Match” option for the question “Which Carpentries workshop are you teaching?”. *This option is only available for Self-Organised workshops. Centrally-Organised workshops are required to follow the Core Curricula.*
 
 ### When we teach our workshops, how closely do we have to stick to the Carpentries lesson plans?
 
-To be considered an official Carpentries workshop, you must follow the [Core Curricula](/workshops/#workshop-core). If you teach something other than what is listed on our webpage, we ask that you acknowledge that your workshop is "inspired by SWC/DC/LC" or "based on SWC/DC/LC". You can still [register]({{< param amy_workshop_landing >}}) your workshop and select the workshop you are teaching is “Mix & Match”, so that we can show others how you use The Carpentries resources.
+To be considered an official Carpentries workshop, you must follow the [Core Curricula](/workshops/host-workshop/#curriculum-requirements-for-centrally-organised-workshops). If you teach something other than what is listed on our webpage, we ask that you acknowledge that your workshop is "inspired by SWC/DC/LC" or "based on SWC/DC/LC". You can still [register]({{< param amy_workshop_landing >}}) your workshop and select the workshop you are teaching is “Mix & Match”, so that we can show others how you use The Carpentries resources.
 
 ## Centrally-Organised Workshops
 
@@ -89,17 +89,17 @@ If your organization does not accept invoices in USD, please let us know. The Wo
 
 ### Is there a fee for running a Self-Organised workshop?
 
-Self-Organised workshops are managed by the instructor/organiser. Since you will be taking care of all the logistics, there is no administrative fee due to The Carpentries for running a Self-Organised workshop. Visit our [website](/workshops/#workshop-organising) for more information.
+Self-Organised workshops are managed by the instructor/organiser. Since you will be taking care of all the logistics, there is no administrative fee due to The Carpentries for running a Self-Organised workshop. Visit our [pricing page](/support/pricing) for more information.
 
 ### How do I inform you I am running a Self-Organised workshop?
 
-When planning a Self-Organised workshop, we ask that you notify us of your planned workshop. Once the workshop webpage is created, please share the link with us and notify us of your planned workshop via the [Self-Organised workshop form]({{< param amy_workshop_landing >}}). Once we receive the link to the workshop webpage, we will be able to [add your workshop to our website](/upcoming_workshops/), provide support (in the form of survey result links and AMI instances for Genomics workshops), and get Instructors and helpers credit for the workshops they teach.
+When planning a Self-Organised workshop, we ask that you notify us of your planned workshop. Once the workshop webpage is created, please share the link with us and notify us of your planned workshop via the [Self-Organised workshop form]({{< param amy_workshop_landing >}}). Once we receive the link to the workshop webpage, we will be able to [add your workshop to our website](/workshops/upcoming-workshops/), provide support (in the form of survey result links and AMI instances for Genomics workshops), and get Instructors and helpers credit for the workshops they teach.
 
 ### If I need help recruiting Instructors and/or helpers for a Self-Organised workshop, what are my options?
 
 If you are organising a Self-Organised workshop, there are resources for you to recruit Instructors and/or helpers. Below are the channels you can use:
 
-* Any local or group specific mailing list on [TopicBox](https://carpentries.topicbox.com/groups)
+* Any local or group specific mailing list on [Topicbox]({{< param topicbox >}})
 * Any local or group specific Slack channel
 
 These channels were designed specifically for community members to communicate about specific needs and to build local capacity.  Recruiting done in any other channel will be removed.
@@ -149,9 +149,9 @@ If you need to postpone your workshop please contact your [Regional Coordinator]
 
 ### What is the difference between a Centrally-Organised workshop and a Self-Organised workshop?
 
-A Centrally-Organised workshop is organised by The Carpentries. We will locate Instructors, setup registration and provide additional support while planning workshops. There is an [administrative fee](/workshops/#workshop-cost) for Centrally-Organised workshops.
+A Centrally-Organised workshop is organised by The Carpentries. We will locate Instructors, setup registration and provide additional support while planning workshops. There is an [administrative fee](/support/pricing) for Centrally-Organised workshops.
 
-A Self-Organised workshop is organised by the workshop instructor/organiser. This means you are already connected with our [certified Instructors](/instructors/) and will work with them on all aspects of workshop organisation. There is no administrative fee for Self-Organised workshops.
+A Self-Organised workshop is organised by the workshop instructor/organiser. This means you are already connected with our [certified Instructors](/community/instructors/) and will work with them on all aspects of workshop organisation. There is no administrative fee for Self-Organised workshops.
 
 ### How do I get survey data/links for previous workshops?
 
@@ -163,7 +163,7 @@ Yes, it is up to the workshop organisers to decide who can attend a workshop. Yo
 
 ### How many times a year do I have to teach to be eligible to vote?
 
-Voting eligibility is dependent on an Instructor's history with The Carpentries. Please see our [Bylaws]({{< param handbook_url >}}/topic_folders/governance/bylaws.html#individual-voting-membership) for more information. 
+Voting eligibility is dependent on an Instructor's history with The Carpentries. Please see our [Bylaws](/about-us/governance/#carpentries-bylaws-and-policies) for more information. 
 
 ### Are there email templates available for me to locate helpers?
 
@@ -179,9 +179,9 @@ Yes, you can charge learners a fee to attend a workshop. It is up to the Host to
 
 ### Can I pay Instructors a stipend?
 
-The Instructors selected to teach workshops are volunteers and are not paid for their service. To compensate for their time, we require the Host to cover travel expenses. If you would like to support our Instructors, you are encouraged to make a targeted [donation](/donate/) to The Carpentries to support instructor development.
+The Instructors selected to teach workshops are volunteers and are not paid for their service. To compensate for their time, we require the Host to cover travel expenses. If you would like to support our Instructors, you are encouraged to make a targeted [donation]({{< param donation_form >}}) to The Carpentries to support instructor development.
 
 
 ## Further Resources
 
-Visit our [Membership FAQ page](/member_faq/) for frequently asked questions specifically relevant to Carpentries Member Organisations.
+Visit our [Membership FAQ page](/support/membership/membership-faq/) for frequently asked questions specifically relevant to Carpentries Member Organisations.

--- a/content/workshops/workshops-faq.md
+++ b/content/workshops/workshops-faq.md
@@ -167,7 +167,7 @@ Voting eligibility is dependent on an Instructor's history with The Carpentries.
 
 ### Are there email templates available for me to locate helpers?
 
-We have compiled several [email templates]({{< param handbook_url >}}/topic_folders/workshop_administration/email_templates.html#from-instructors-and-hosts) for you to be able to respond to various groups: participants, instructors, and helpers.
+We have compiled several [email templates]({{< param handbook_url >}}/topic_folders/workshop_administration/email_templates.html#from-instructors-and-hosts) for you to be able to respond to various groups: participants, Instructors, and helpers.
 
 ### I do not see a [Regional Coordinator](/regionalcoordinators/) for my area. Who should I speak with regarding a workshop?
 


### PR DESCRIPTION
Addresses many of the points in #223 by updating language and links. 

* Questions about capitalizing "Host" still remain. 
* Links to online workshop recommendations have not been addressed as we are transitioning that to the handbook
* Questions about workshop operations (travel costs, RC role, etc) have not been addressed as they need review by WIT