### PR TITLE
Add DEIA statement to bottom of about-us page 

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -88,3 +88,7 @@ swc-website: https://swc-new-website.netlify.app/
 # Other sites
 #############################################
 handbook_url: https://docs.carpentries.org
+
+# Other forms
+#############################################
+accommodation_request: https://carpentries.typeform.com/to/B2OSYaD0

--- a/content/about-us/_index.md
+++ b/content/about-us/_index.md
@@ -102,3 +102,15 @@ At The Carpentries, we are committed to building a diverse, equitable, and inclu
 The Carpentries is committed to providing inclusive and accessible content that enables all individuals, including those with disabilities, to participate and engage fully. We are actively working to increase the accessibility and usability of Carpentries’ content and in doing so adhere to many of the available standards and guidelines including those from the World Wide Web Consortium.
 
 If there are any aspects of our community including the website, community discussions, instruction, or the design of our lessons that result in barriers to your inclusion, please [email us](mailto:{{< param team_email >}}) with as much information as possible including the name, location, and date of the event you attended, or any relevant links that provide context (e.g. Slack, GitHub).
+
+### Request an accommodation
+
+At The Carpentries, we are committed to building a diverse, equitable, and inclusive community that values all individuals and their unique identities. We prioritise accessibility and inclusivity in our curricula and programs and value transparency, fairness, and honesty to build trust within our community. Building an inclusive community is an ongoing process that requires consistent effort and commitment, and we strive for continuous improvement.
+
+To request an accommodation for a Carpentries event, please fill out the [accommodation_request form]({{< param accommodation_request >}}).
+
+If you have questions or need assistance with the accommodation form please [email us](mailto:{{< param team_email>}}).
+
+### Resources
+
+[The Toolkit of IDEAS](https://zenodo.org/records/10391883) (Inclusion, Diversity, Equity and Accessibility Strategies) is a practical resource for Carpentries’ Instructors, helpers, and workshop hosts. We know that many people care about inclusion, diversity, equity and accessibility but are not sure how it connects to teaching foundational coding and data science skills. This toolkit aims to bridge this gap. This is version 1, which means it is a starting point and not a fully comprehensive resource. The hope is that the Core Team and community members will continue to update and extend this resource over time.


### PR DESCRIPTION
Following conversation in #183, this puts the statement at the bottom of the about us page so it can be linked to from anywhere.