### PR TITLE
add tools to lesson data for spanish lessons

### DIFF
--- a/data/lessons.yaml
+++ b/data/lessons.yaml
@@ -57,7 +57,7 @@
     program: SWC
     name: La Terminal de Unix
     description:
-    tool:
+    tool: Shell
     skill:
     language: Spanish
     domain: General
@@ -66,7 +66,7 @@
     program: SWC
     name: Control de versiones con Git
     description:
-    tool:
+    tool: Git
     skill:
     language: Spanish
     domain: General
@@ -75,7 +75,7 @@
     program: SWC
     name: R para Análisis Científicos Reproducibles
     description:
-    tool:
+    tool: R
     skill:
     language: Spanish
     domain: General
@@ -273,7 +273,7 @@
     program: DC
     name: Análisis y visualización de datos usando Python
     description: (beta)
-    tool:
+    tool: Python
     skill:
     language: Spanish
     domain: Ecology


### PR DESCRIPTION
Addresses #267.
Spanish language lessons were not showing up in search results because the source data was not correctly set.