### PR TITLE
Use real URLs (not netlify previews)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## The Carpentries website
 
-This is the repo for the new Carpentries website.  The site is built using [The Carpentries Hugo theme](https://github.com/carpentries/carpentries-hugo-theme) and can be previewed [here](https://carp-new-website.netlify.app/).  
+This is the repo for [The Carpentries website](https://carpentries.org).  The site is built using [The Carpentries Hugo theme](https://github.com/carpentries/carpentries-hugo-theme).  
 
- To build this site locally, follow the instructions in the theme's repo.
+To build this site locally, follow the instructions in the theme's repo.
 
 Run `make serve` in your project's folder to serve the site locally.

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -6,13 +6,13 @@ top:
     params:
       active: true
   - name: Data Carpentry
-    url: https://dc-new-website.netlify.app/
+    url: https://datacarpentry.org/
     weight: 20
   - name: Library Carpentry
-    url: https://lc-new-website.netlify.app/
+    url: https://librarycarpentry.org/
     weight: 30
   - name: Software Carpentry
-    url: https://swc-new-website.netlify.app/
+    url: https://software-carpentry.org/
     weight: 40
 # About page tabbed menu
 about:
@@ -175,7 +175,7 @@ main:
   weight: 20
 - identifier: handbook
   name: Handbook
-  url: "https://carpentries-beta-handbook-preview.netlify.app/"
+  url: "https://docs.carpentries.org"
   parent: volunteer
   weight: 30
 - identifier: amy

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -80,9 +80,9 @@ workbench_link: https://carpentries.github.io/workbench/
 
 # Lesson programs
 #############################################
-dc-website: https://dc-new-website.netlify.app/
-lc-website:  https://lc-new-website.netlify.app/
-swc-website: https://swc-new-website.netlify.app/
+dc-website: https://datacarpentry.org
+lc-website:  https://librarycarpentry.org/
+swc-website: https://software-carpentry.org/
 
 
 # Other sites

--- a/content/community/get-involved.md
+++ b/content/community/get-involved.md
@@ -5,7 +5,7 @@ widgets:
 - newsletter
 ---
 
-You can get involved with The Carpentries by volunteering in one of our [community roles](https://carp-new-website.netlify.app/community/). To find out more about the duties and benefits of volunteering in these roles, as well as how to be onboarded onto and offboarded from these roles, please visit our [Handbook](https://carpentries-beta-handbook-preview.netlify.app/)
+You can get involved with The Carpentries by volunteering in one of our [community roles](/community/). To find out more about the duties and benefits of volunteering in these roles, as well as how to be onboarded onto and offboarded from these roles, please visit our [Handbook](https://docs.carpentries.org)
 
 * We also keep our community strong and connected through meetups (virtual and in-person) and interest-specific mailing lists.
 	* [Regional Subcommunities](/community/get-connected/#subcommunity-registry)

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://carp-new-website.netlify.app/
+baseURL: https://carpentries.org
 languageCode: en-us
 title: The Carpentries
 module:


### PR DESCRIPTION
Use the site's actual URL (carpentries.org) instead of the netlify previews.