### PR TITLE
move topicbox lists to handbook

### DIFF
--- a/content/community/get-connected.md
+++ b/content/community/get-connected.md
@@ -46,41 +46,4 @@ The subcommunities listed in this section are those whose focus is Carpentries a
 
 All [mailing lists for The Carpentries]({{< param topicbox >}}) are hosted on Topicbox.  This includes a number of mailing lists specific to local or regional communities.
 
-### Africa
-- [Africa]({{< param topicbox >}}/local-africa)
-- [Middle-East and North Africa]({{< param topicbox >}}/local-middle-east)
-
-### Asia
-- [Bangladesh]({{< param topicbox >}}/local-bangladesh)
-- [India]({{< param topicbox >}}/local-india)
-
-### Australia/New Zealand
-- [Australia and New Zealand]({{< param topicbox >}}/local-aunz)
-
-### Canada
-- [Vancouver]({{< param topicbox >}}/local-vancouver)
-
-### Europe
-- [Germany]({{< param topicbox >}}/local-germany)
-- [Heidelberg]({{< param topicbox >}}/local-heidelberg)
-- [United Kingdom]({{< param topicbox >}}/local-uk)
-- [Nordic countries]({{< param topicbox >}}/local-nordic)
-- [North Rhine-Westphalia, Germany]({{< param topicbox >}}/local-nrw)
-
-### Latin America
-- [Latin America]({{< param topicbox >}}/local-latinoamerica)
-- [Puerto Rico]({{< param topicbox >}}/local-puertorico)
-
-### United States
-- [Bay Area]({{< param topicbox >}}/local-bayarea)
-- [Boston]({{< param topicbox >}}/local-boston)
-- [Colorado]({{< param topicbox >}}/local-colorado)
-- [Davis, CA]({{< param topicbox >}}/local-davis)
-- [Lansing, MI]({{< param topicbox >}}/local-lansing)
-- [Merced, CA]({{< param topicbox >}}/local-merced)
-- [Seattle, WA]({{< param topicbox >}}/local-seattle)
-- [Southeast US Library Carpentry]({{< param topicbox >}}/local-libcarpentry-southeast-u)
-- [Southern California]({{< param topicbox >}}/local-socal)
-- [Southwest United States]({{< param topicbox >}}/local-swusa)
-- [University of California]({{< param topicbox >}}/local-uc)
-- [Washington DC Area]({{< param topicbox >}}/local-dc) 
+On how to join the mailing lists and use TopicBox, [please refer to our TopicBox Quick Start Guide]({{< param handbook_url >}}/resources/communications/slack-and-email.html#topicbox).


### PR DESCRIPTION
Addresses https://github.com/carpentries/docs.carpentries.org/issues/376 by moving list of topicbox lists from website to handbook.