### PR TITLE
Add Workbench page

### DIFF
--- a/content/lessons/_index.md
+++ b/content/lessons/_index.md
@@ -12,7 +12,7 @@ All lessons are self-contained, but many form part of a larger curriculum and ar
 
 All of our lessons have been collaboratively developed by members of The Carpentries community, and subsequently updated and polished based on extensive testing and feedback from Instructors.
 
-Our lessons are built using the [Workbench](/workbench), a custom open-source software framework written in R.
+Our lessons are built using [The Carpentries Workbench](/workbench), a custom open-source software framework written in R.
 
 ## Search lessons
 

--- a/content/lessons/_index.md
+++ b/content/lessons/_index.md
@@ -12,6 +12,8 @@ All lessons are self-contained, but many form part of a larger curriculum and ar
 
 All of our lessons have been collaboratively developed by members of The Carpentries community, and subsequently updated and polished based on extensive testing and feedback from Instructors.
 
+Our lessons are built using the [Workbench](/workbench), a custom open-source software framework written in R.
+
 ## Search lessons
 
 Our lesson collection is extensive. Use the search bar to find a particular lesson (e.g. The Unix Shell) or lessons related to a general topic (e.g. data organisation). Use the filtering options to narrow down your results or browse lessons by category.  Clear filters before performing a new search.

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -56,3 +56,4 @@ We also provide a pre-built Docker image that is used for our official GitHub le
 
 Have you used the Workbench in your own lessons or teaching materials? Please do cite us!
 
+Kamvar, Z. N., Davey, R., Armstrong, M., Barnes, K., Becker, E., Bellini Saibene, Y., Brown, S., Chisholm, R., Colomb, J., Companjen, B., Feickert, M., Gruson, H., Hodges, T., Michonneau, F., Malfait, M., Nitta, J. H., Konovalov, O., Raden, M., Reed, P., Sheargrub, Theodorakis, D., (2025). **The Carpentries Workbench**. https://carpentries.org/workbench

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -7,7 +7,7 @@ hideToc: false
 The Carpentries Workbench is a open-source and portable lesson infrastructure built with the R programming language.
 We aim to provide a robust software framework so The Carpentries and its community is able to freely build reliable, stylish, and accessible online learning materials.
 
-All our lessons across our lesson programs, including those in development in the Carpentries Incubator and Lab, are built using the Workbench.
+All our lessons across our lesson programs, including those in development in the [Carpentries Incubator](https://carpentries-incubator.org/) and [Lab](https://carpentries-lab.org/), are built using the Workbench.
 
 We welcome contributions to the Workbench so please do connect with us over on GitHub!
 

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -1,0 +1,58 @@
+---
+title: The Carpentries Workbench
+layout: single
+hideToc: false
+---
+
+The Carpentries Workbench is a open-source and portable lesson infrastructure built with the R programming language.
+We aim to provide a robust software framework so the Carpentries and its community is able to freely build reliable, stylish, and accessible online learning materials.
+
+All our lessons across our lesson programs, including those in development in the Carpentries Incubator and Lab, are built using the Workbench.
+
+We welcome contributions to the Workbench so please do connect with us over on GitHub!
+
+
+## Source Code
+
+The code for the Workbench is open sourced under a permissible MIT licence.
+
+It comprises three R packages:
+
+- [pegboard](https://github.com/carpentries/pegboard)
+- [sandpaper](https://github.com/carpentries/sandpaper)
+- [varnish](https://github.com/carpentries/varnish)
+
+
+## Prebuilt Packages
+
+### conda
+
+There are conda packages available for the Workbench software:
+
+- [pegboard](https://anaconda.org/conda-forge/r-pegboard)
+- [sandpaper](https://anaconda.org/conda-forge/r-sandpaper)
+- [varnish](https://anaconda.org/conda-forge/r-varnish)
+
+### docker
+
+We also provide a pre-built Docker image that is used for our official GitHub lesson builds, and can be used locally for your own:
+
+- [workbench-docker](https://github.com/carpentries/workbench-docker) ([dockerhub](https://hub.docker.com/r/carpentries/workbench-docker))
+
+
+## Documentation
+
+- [Workbench](https://carpentries.github.io/workbench/)
+
+- [Pegboard Vignettes](https://carpentries.r-universe.dev/pegboard/doc/manual.html)
+- [Sandpaper Vignettes](https://carpentries.r-universe.dev/sandpaper/doc/manual.html)
+- [Varnish Vignettes](https://carpentries.r-universe.dev/varnish/doc/manual.html)
+
+- [Workbench Developers Guide](https://carpentries.github.io/workbench-dev/)
+
+- [Workbench Docker](https://github.com/carpentries/workbench-docker?tab=readme-ov-file#prerequisites)
+
+## Cite The Workbench
+
+Have you used the Workbench in your own lessons or teaching materials? Please do cite us!
+

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -18,22 +18,22 @@ The code for the Workbench is open sourced under a permissible MIT licence.
 
 It comprises three R packages:
 
-- [pegboard](https://github.com/carpentries/pegboard)
-- [sandpaper](https://github.com/carpentries/sandpaper)
-- [varnish](https://github.com/carpentries/varnish)
+- [{pegboard}](https://github.com/carpentries/pegboard)
+- [{sandpaper}](https://github.com/carpentries/sandpaper)
+- [{varnish}](https://github.com/carpentries/varnish)
 
 
 ## Prebuilt Packages
 
-### conda
+### Conda
 
 There are conda packages available for the Workbench software:
 
-- [pegboard](https://anaconda.org/conda-forge/r-pegboard)
-- [sandpaper](https://anaconda.org/conda-forge/r-sandpaper)
-- [varnish](https://anaconda.org/conda-forge/r-varnish)
+- [r-pegboard](https://anaconda.org/conda-forge/r-pegboard)
+- [r-sandpaper](https://anaconda.org/conda-forge/r-sandpaper)
+- [r-varnish](https://anaconda.org/conda-forge/r-varnish)
 
-### docker
+### Docker
 
 We also provide a pre-built Docker image that is used for our official GitHub lesson builds, and can be used locally for your own:
 
@@ -44,9 +44,9 @@ We also provide a pre-built Docker image that is used for our official GitHub le
 
 - [Workbench](https://carpentries.github.io/workbench/)
 
-- [Pegboard Vignettes](https://carpentries.r-universe.dev/pegboard/doc/manual.html)
-- [Sandpaper Vignettes](https://carpentries.r-universe.dev/sandpaper/doc/manual.html)
-- [Varnish Vignettes](https://carpentries.r-universe.dev/varnish/doc/manual.html)
+- [{pegboard} Vignettes](https://carpentries.r-universe.dev/pegboard/doc/manual.html)
+- [{sandpaper} Vignettes](https://carpentries.r-universe.dev/sandpaper/doc/manual.html)
+- [{varnish} Vignettes](https://carpentries.r-universe.dev/varnish/doc/manual.html)
 
 - [Workbench Developers Guide](https://carpentries.github.io/workbench-dev/)
 

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -7,7 +7,7 @@ hideToc: false
 The Carpentries Workbench is a open-source and portable lesson infrastructure built with the R programming language.
 We aim to provide a robust software framework so The Carpentries and its community is able to freely build reliable, stylish, and accessible online learning materials.
 
-All our lessons across our lesson programs, including those in development in the [Carpentries Incubator](https://carpentries-incubator.org/) and [Lab](https://carpentries-lab.org/), are built using the Workbench.
+All our lessons across our lesson programs, including those in development in [The Carpentries Incubator](https://carpentries-incubator.org/) and [Lab](https://carpentries-lab.org/), are built using the Workbench.
 
 We welcome contributions to the Workbench so please do connect with us over on GitHub!
 

--- a/content/workbench/_index.md
+++ b/content/workbench/_index.md
@@ -5,7 +5,7 @@ hideToc: false
 ---
 
 The Carpentries Workbench is a open-source and portable lesson infrastructure built with the R programming language.
-We aim to provide a robust software framework so the Carpentries and its community is able to freely build reliable, stylish, and accessible online learning materials.
+We aim to provide a robust software framework so The Carpentries and its community is able to freely build reliable, stylish, and accessible online learning materials.
 
 All our lessons across our lesson programs, including those in development in the Carpentries Incubator and Lab, are built using the Workbench.
 


### PR DESCRIPTION
This PR adds a dedicated `/workbench` page to use for pointing to the software and its documentation.

It also acts as a persistent URL for citing the software.