### PR TITLE
New membership model survey blog post

### DIFF
--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -4,7 +4,7 @@ authors: ["Erin Becker", "Kari L. Jordan"]
 teaser: "The Carpentries has developed a draft vision for the new membership model, and would like your input towards its final design."  
 title: "We're Almost There: Share Your Input on The Carpentries' New Membership Model"  
 date: 2025-09-17  
-time: "18:00:00"  
+time: "08:00:00"  
 tags: ["Membership", "Feedback", "Community"]  
 ---
 
@@ -29,6 +29,7 @@ Your input now will shape the final version of our new membership program, ensur
 {.button}
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 
 
 

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -14,7 +14,7 @@ Last year, many of you shared your perspectives in our [2024 member survey](http
 
 We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
 
-[Take the survey now]({{< https://carpentries.typeform.com/to/toWWTXNW >}})
+[Take the survey now]({{< param https://carpentries.typeform.com/to/toWWTXNW >}})
 {.button}
 
 [Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
@@ -31,5 +31,6 @@ Your input now will shape the final version of our new membership program, ensur
 {.button}
 
 [Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
+
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -14,7 +14,8 @@ Last year, many of you shared your perspectives in our [2024 member survey](http
 
 We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
 
-[Take the Survey Now]
+[Take the Survey Now](https://carpentries.typeform.com/to/toWWTXNW)
+{.button}
 
 By sharing your thoughts, you'll help us ensure our new program is:
 
@@ -24,9 +25,11 @@ By sharing your thoughts, you'll help us ensure our new program is:
 
 Your input now will shape the final version of our new membership program, ensuring it is truly co-created with the people who make The Carpentries what it is.
 
-[Take the Survey Now]
+[Take the Survey Now](https://carpentries.typeform.com/to/toWWTXNW)
+{.button}
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 
 
 

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -17,8 +17,6 @@ We've developed a draft vision for the new membership model, and we want to make
 [Take the survey now]({{< param https://carpentries.typeform.com/to/toWWTXNW >}})
 {.button}
 
-[Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
-
 By sharing your thoughts, you'll help us ensure our new program is:
 
 * **Community-centered** – built around the values and needs of our global network.  
@@ -30,7 +28,5 @@ Your input now will shape the final version of our new membership program, ensur
 [Take the survey now]({{< https://carpentries.typeform.com/to/toWWTXNW >}})
 {.button}
 
-[Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
-
-
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -1,0 +1,35 @@
+---  
+layout: page  
+authors: ["Erin Becker", "Kari L. Jordan"]  
+teaser: "The Carpentries has developed a draft vision for the new membership model, and would like your input towards its final design."  
+title: "We're Almost There: Share Your Input on The Carpentries' New Membership Model"  
+date: 2025-09-16  
+time: "18:00:00"  
+tags: ["Membership", "Feedback", "Community"]  
+---
+
+The Carpentries is evolving — and so is our membership program. To remain a strong, sustainable community of practice, we are finalising a new model that reflects today's realities, tomorrow's opportunities, and, most importantly, the needs of our community.
+
+Last year, many of you shared your perspectives in our [2024 member survey](https://carpentries.org/blog/2024/09/launching-the-carpentries-membership-program-survey/). Your feedback was invaluable — it highlighted where our membership program could be more relevant, flexible, and supportive. That input has guided our redesign, and now we're ready to take the next step.
+
+We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
+
+[Take the survey now]({{< https://carpentries.typeform.com/to/toWWTXNW >}})
+{.button}
+
+[Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
+
+By sharing your thoughts, you'll help us ensure our new program is:
+
+* **Community-centered** – built around the values and needs of our global network.  
+* **Sustainable** – financially resilient and future-ready.  
+* **Flexible** – responsive to the diverse contexts of the organisations we serve.
+
+Your input now will shape the final version of our new membership program, ensuring it is truly co-created with the people who make The Carpentries what it is.
+
+[Take the survey now]({{< https://carpentries.typeform.com/to/toWWTXNW >}})
+{.button}
+
+[Take the survey now](https://carpentries.typeform.com/to/toWWTXNW){: .btn}
+
+Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -14,8 +14,7 @@ Last year, many of you shared your perspectives in our [2024 member survey](http
 
 We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
 
-[Take the survey now]({{< param https://carpentries.typeform.com/to/toWWTXNW >}})
-{.button}
+[Take the survey now]
 
 By sharing your thoughts, you'll help us ensure our new program is:
 
@@ -25,8 +24,8 @@ By sharing your thoughts, you'll help us ensure our new program is:
 
 Your input now will shape the final version of our new membership program, ensuring it is truly co-created with the people who make The Carpentries what it is.
 
-[Take the survey now]({{< https://carpentries.typeform.com/to/toWWTXNW >}})
-{.button}
+[Take the survey now]
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -14,7 +14,7 @@ Last year, many of you shared your perspectives in our [2024 member survey](http
 
 We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
 
-[Take the survey now]
+[Take the Survey Now]
 
 By sharing your thoughts, you'll help us ensure our new program is:
 
@@ -24,8 +24,9 @@ By sharing your thoughts, you'll help us ensure our new program is:
 
 Your input now will shape the final version of our new membership program, ensuring it is truly co-created with the people who make The Carpentries what it is.
 
-[Take the survey now]
+[Take the Survey Now]
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 
 

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -10,7 +10,7 @@ tags: ["Membership", "Feedback", "Community"]
 
 The Carpentries is evolving — and so is our membership program. To remain a strong, sustainable community of practice, we are finalising a new model that reflects today's realities, tomorrow's opportunities, and, most importantly, the needs of our community.
 
-Last year, many of you shared your perspectives in our [2024 member survey](https://carpentries.org/blog/2024/09/launching-the-carpentries-membership-program-survey/). Your feedback was invaluable — it highlighted where our membership program could be more relevant, flexible, and supportive. That input has guided our redesign, and now we're ready to take the next step.
+Last year, many of you shared your perspectives in our [2024 member survey](/blog/2024/09/launching-the-carpentries-membership-program-survey/). Your feedback was invaluable — it highlighted where our membership program could be more relevant, flexible, and supportive. That input has guided our redesign, and now we're ready to take the next step.
 
 We've developed a draft vision for the new membership model, and we want to make sure it reflects what matters most to you. Our follow-up survey focuses on specific questions that will directly influence the final design.
 
@@ -29,6 +29,7 @@ Your input now will shape the final version of our new membership program, ensur
 {.button}
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 
 
 

--- a/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
+++ b/content/posts/2025/09/share-your-input-on-the-carpentries-new-membership-model.md
@@ -3,7 +3,7 @@ layout: page
 authors: ["Erin Becker", "Kari L. Jordan"]  
 teaser: "The Carpentries has developed a draft vision for the new membership model, and would like your input towards its final design."  
 title: "We're Almost There: Share Your Input on The Carpentries' New Membership Model"  
-date: 2025-09-16  
+date: 2025-09-17  
 time: "18:00:00"  
 tags: ["Membership", "Feedback", "Community"]  
 ---
@@ -29,6 +29,7 @@ Your input now will shape the final version of our new membership program, ensur
 {.button}
 
 Thank you for lending your perspective once again. With your partnership, we're building the future of The Carpentries together.
+
 
 
 


### PR DESCRIPTION
Hi @maneesha, I have run into some trouble getting the survey link to render as an html [button similar to our previous buttons in our blog posts](https://www.carpentries.org/blog/2025/08/on-the-importance-of-agility-and-values-aligned-decisions-making/). 

In this blog post/PR, could you please make "Take the Survey Now" (appears twice) a button, linking to this URL:  https://carpentries.typeform.com/to/toWWTXNW. 

Thereafter you can merge the post. 