### PR TITLE
Fix link to /community/get-involved/

### DIFF
--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -9,4 +9,4 @@ aliases:
 
 We are grateful to the individuals and organisations who provide financial support to The Carpentries. If you are interested in supporting our work, you can learn more about becoming a [Member Organisation](/support/membership/), [sponsor](/sponsorship/), or [donor]({{< param donate_url >}}). Your contributions help us create positive change in the data and software communities.
 
-Just as important as financial contributions is the support that individuals and organisations give to The Carpentries by [getting involved](/get-involved/) in a wide range of activities and volunteer roles.
+Just as important as financial contributions is the support that individuals and organisations give to The Carpentries by [getting involved](/community/get-involved/) in a wide range of activities and volunteer roles.


### PR DESCRIPTION
Was this just a typo, or did the relative location of the get-involved page change?
In any case, love the work here!