### PR TITLE
initial setup of Carpentries-hosted workshops page

### DIFF
--- a/content/workshops/carpentries_hosted.md
+++ b/content/workshops/carpentries_hosted.md
@@ -1,0 +1,15 @@
+---
+title: Carpentries Hosted Workshops
+layout: workshops
+data_source: https://feeds.carpentries.org/all_upcoming_workshops.json
+hideToc: true
+aliases:
+- /carpentries_hosted_workshops/
+host: The Carpentries Workshops
+hide_sidebar_search: true
+---
+
+**PLACEHOLDER TEXT** The Carpentries hosts workshops directly... some language here about open to everyone... no institutional affiliation required...what else? 
+Here are our upcoming Carpentries hosted workshops.
+
+Learn about our other [upcoming workshops](/workshops/upcoming-workshops).


### PR DESCRIPTION
This PR is for the initial setup and preview of a page listing only Carpentries-hosted workshops. This is a draft - do not merge.