### PR TITLE
DRAFT: Person profiles

### DIFF
--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -1,4 +1,4 @@
-{{ $persons := .Site.Data.badges }}
+{{ $persons := .Site.Data.people }}
 
 {{ range $persons }}
   {{ if and .person_name (ne .person_name "") }}

--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -18,6 +18,10 @@
         "maintainer" (string .maintainer)
         "instructor" (string .instructor)
         "trainer" (string .trainer)
+        "cldt" (string .cldt)
+        "url" .url
+        "orcid" .orcid
+        "bluesky" .bluesky
       )
     }}
     {{ $.AddPage $content }}

--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -2,6 +2,18 @@
 
 {{ range $persons }}
   {{ if and .person_name (ne .person_name "") }}
+
+   {{ $instructor_activity_array := slice }}
+   {{ if .instructor_activity_list }}
+      {{ $instructor_activity_array = split .instructor_activity_list "," }}
+   {{ end }}
+
+   {{ $helper_activity_array := slice }}
+   {{ if .helper_activity_list }}
+      {{ $helper_activity_array = split .helper_activity_list "," }}
+   {{ end }}
+
+
     {{ $content := dict
       "path" (.person_name | urlize)
       "title" .person_name
@@ -12,8 +24,9 @@
         "personal" .personal
         "country" .country
         "twitter" .twitter
-        "active_status" .active_status
         "instructor_activity_list" .instructor_activity_list
+        "instructor_act" $instructor_activity_array
+        "helper_act" $helper_activity_array
         "helper_activity_list" .helper_activity_list
         "badges" .badges 
         "maintainer" (string .maintainer)

--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -13,7 +13,8 @@
         "country" .country
         "twitter" .twitter
         "active_status" .active_status
-        "workshop_list" .workshop_list
+        "instructor_activity_list" .instructor_activity_list
+        "helper_activity_list" .helper_activity_list
         "badges" .badges 
         "maintainer" (string .maintainer)
         "instructor" (string .instructor)

--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -1,0 +1,33 @@
+{{ $url := "https://feeds.carpentries.org/all_badged_people.json" }}
+
+
+{{ with resources.GetRemote $url }}
+  {{ with .Err }}
+    {{ errorf "Failed to fetch persons data: %s" . }}
+  {{ else }}
+    {{ $data := . | transform.Unmarshal }}
+    
+    {{ $persons := $data }}
+    {{ if reflect.IsMap $data }}
+      {{ $persons = index $data "persons" }}
+    {{ end }}
+    
+    {{ range $persons }}
+      {{ $content := dict
+        "path" (string .person_name)
+        "title" .person_name
+        "params" (dict
+          "github" (string .github)
+          "person_name" (string .person_name)
+          "country" (string .country)
+          "twitter" (string .twitter)
+          "badges" (string .badges)
+          "maintainer" .is_maintainer
+          "trainer" .is_trainer
+          "instructor" .is_instructor
+        )
+      }}
+      {{ $.AddPage $content }}
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/content/persons/_content.gotmpl
+++ b/content/persons/_content.gotmpl
@@ -1,33 +1,27 @@
-{{ $url := "https://feeds.carpentries.org/all_badged_people.json" }}
+{{ $persons := .Site.Data.badges }}
 
-
-{{ with resources.GetRemote $url }}
-  {{ with .Err }}
-    {{ errorf "Failed to fetch persons data: %s" . }}
+{{ range $persons }}
+  {{ if and .person_name (ne .person_name "") }}
+    {{ $content := dict
+      "path" (.person_name | urlize)
+      "title" .person_name
+      "params" (dict
+        "person_name" .person_name
+        "github" .github
+        "family" .family
+        "personal" .personal
+        "country" .country
+        "twitter" .twitter
+        "active_status" .active_status
+        "workshop_list" .workshop_list
+        "badges" .badges 
+        "maintainer" (string .maintainer)
+        "instructor" (string .instructor)
+        "trainer" (string .trainer)
+      )
+    }}
+    {{ $.AddPage $content }}
   {{ else }}
-    {{ $data := . | transform.Unmarshal }}
-    
-    {{ $persons := $data }}
-    {{ if reflect.IsMap $data }}
-      {{ $persons = index $data "persons" }}
-    {{ end }}
-    
-    {{ range $persons }}
-      {{ $content := dict
-        "path" (string .person_name)
-        "title" .person_name
-        "params" (dict
-          "github" (string .github)
-          "person_name" (string .person_name)
-          "country" (string .country)
-          "twitter" (string .twitter)
-          "badges" (string .badges)
-          "maintainer" .is_maintainer
-          "trainer" .is_trainer
-          "instructor" .is_instructor
-        )
-      }}
-      {{ $.AddPage $content }}
-    {{ end }}
+    {{ warnf "Missing data: %v" . }}
   {{ end }}
 {{ end }}

--- a/content/persons/_index.html
+++ b/content/persons/_index.html
@@ -1,0 +1,3 @@
+---
+title: "The Carpentries Community"
+---

--- a/layouts/persons/list.html
+++ b/layouts/persons/list.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+ <div class="container px-5 mx-auto">
+    {{ partial "breadcrumbs" . }}
+    <h1 class="text-[2rem] leading-[2.8125rem] font-semibold mb-6">{{ .Title }}</h1>
+    <div class="relative grid gap-8 md:grid-cols-12">
+      <div class="col-span-8 pb-16 pro">
+<ul class="persons-list">
+  {{ range .Pages }}
+  <li>
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  </li>
+  {{ end }}
+</ul>
+      </div>
+
+    </div>
+
+  </div>
+
+{{ end }}
+
+
+

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -1,0 +1,100 @@
+{{ define "main" }}
+  <div class="container px-5 pb-10 mx-auto">
+    {{ partial "breadcrumbs" . }}
+      <h1 class="text-[2rem] leading-[2.8125rem] font-semibold">{{ .Title }}</h1>
+    <div
+      x-data="{
+        currentSection: 0,
+        currentSectionTitle: 'First'
+      }"
+    class="relative grid grid-cols-1 gap-8 md:grid-cols-12">
+      <div class="pb-16 md:col-span-9 md:pr-20">
+        <div class="prose h2-wrap max-w-none">
+
+
+
+<article class="person-profile">
+
+        <p>Everything here is proof of concept - that we can pull data from AMY and display it on this page.  Styling clearly needs a lot of work.</p>
+
+        {{ with .Params.github }}
+        <p><img src="https://avatars.githubusercontent.com/{{ . }}" alt="Avatar"></p>
+        <div class="profile-details">
+        {{ end }}          
+
+        <p><b>If we added a long text field like "bio" to AMY person profiles,
+          then we could give people the option to display a short bio about themselves
+          here.  Technology part of that is easy but we may want to consider if we want this as we can't control the message here.
+        </b>  Cotton candy gingerbread cookie pie sweet pudding fruitcake chocolate bar muffin. Cake marshmallow jelly cheesecake dessert donut muffin. Cheesecake wafer icing pie oat cake bonbon tiramisu topping. Soufflé gummies sugar plum chocolate bar bonbon powder toffee macaroon biscuit. Pie cheesecake dragée chocolate sweet sugar plum oat cake wafer sweet roll.  </p>
+        
+        <p>We could also add in stats like "Instructor since 15 February 2015" or "15 workshops taught".</p>
+
+        <p>We may also want to consider a new consent as we are now displaying information in a new way.</p>
+
+
+        <p><strong>Country:</strong> {{ .Params.country }}</p>
+
+        <h2>Find Me</h2>
+        <p><strong>GitHub:</strong> 
+        <a href="https://github.com/{{ .Params.github }}">@{{ .Params.github }}</a>
+        </p>
+        <p><strong>Website:</strong> <a href="{{ .Params.url }}">{{ .Params.url }}</a></p>
+        <p><strong>ORCID:</strong> {{ .Params.orcid }}</p>
+        <p><strong>Bluesky:</strong>{{ .Params.bluesky }}</p>
+        {{ with .Params.twitter }}
+        <p><strong>Twitter:</strong><a href="https://twitter.com/{{ . }}">@{{ . }}</a>  </p>
+        {{ end }}
+
+        <h2>My Badges</h2>
+        <p>Instructor/Trainer/etc. below refer to the badge, not the active role. As we develop "active status" definitions/systems, we can add in both badge and role. </p>
+        <p><strong>Badges:</strong> {{ .Params.badges }}</p>
+        <p><strong>Maintainer:</strong> {{ .Params.maintainer }}</p>
+        <p><strong>Instructor:</strong> {{ .Params.instructor }}</p>
+        <p><strong>Instructor Trainer:</strong> {{ .Params.trainer }}</p>
+        <p><strong>Curriculum Development Trainer:</strong> {{ .Params.cldt }}</p>
+
+
+        <h2>My Teaching Activity</h2>
+
+        <p>We need a better way to display this, as slugs are generally meaningless outside of our internal systems.  We could display workshop lesson program/curriculum, host site, etc.</p>
+
+        <p>We will also need to consider workshops where the host has asked the workshop not be publicly listed.</p>
+
+        <p><strong>Workshops (Instructor):</strong>     
+          {{ with .Params.instructor_act }}
+          <p>{{ len . }} {{ cond (eq (len .) 1) "workshop" "workshops" }}</p>
+
+              <ul>
+                {{ range . }}
+                <li>{{ . }}</li>
+                {{ end }}
+              </ul>
+            {{ end }}
+          </p>
+
+
+        <p><strong>Workshops (Helper):</strong>
+
+          {{ with .Params.helper_act }}
+          <p>{{ len . }} {{ cond  (eq (len .) 0) "none" (cond (eq (len .) 1) "workshop" "workshops") }}</p>
+
+              <ul>
+
+                {{ range . }}
+                <li>{{ . }}</li>
+                {{ end }}
+              </ul>
+            {{ end }}
+          </p>
+        </article>
+        </div>
+      </div>
+      <div class="relative md:col-span-3">
+        <div class="sticky top-10 sidebar" x-data="{ selected: null }">
+          {{ .Render "sidebar" }} 
+       </div>
+      </div>
+    </div>
+  </div>
+
+{{ end }}


### PR DESCRIPTION
This is a draft PR - DO NOT MERGE.

This is a proof of concept for how we can use Hugo's [content adapters](https://gohugo.io/content-management/content-adapters/) to dynamically generate a person list and individual person profile pages from a json file.  It only shows that is it possible to do so and does not account for what we want to display or how we want to display it.  I'm putting in this PR only so that the source code lives somewhere other than my local machine.

This requires a file called `people.json` to be in the `data` folder.  Currently, the file must have the following structure.  This can change based on what we decide to display.

```
[
  {
    "id": 12345,
    "person_name": "Cheese Pizza",
    "person_email": "pizza@example.com",
    "github": "pizza100",
    "twitter": "",
    "orcid": "https://orcid.org/1234-5678-1234-5678",
    "bluesky": "",
    "url": "",
    "country": "",
    "iata": "",
    "latitude": "",
    "longitude": "",
    "badges": "13,7",
    "publish_profile": 1,
    "lesson_publication_consent": "unset",
    "instructor_activity_list": "2024-03-04-ABCD,2025-06-15-XYZ",
    "helper_activity_list": "2025-11-20-univ",
    "instructor": true,
    "maintainer": false,
    "trainer": true,
    "cldt": false
  },...]
```



