### PR TITLE
Remove link to Instructors page

### DIFF
--- a/content/community/instructors.md
+++ b/content/community/instructors.md
@@ -7,7 +7,7 @@ aliases:
 
 Carpentries Instructors are the core of our community. Instructors organise and teach Carpentries workshops to spread data literacy and programmatic skills both locally and globally. Members of our Instructor community work together to actively grow their instructional and technical skills. Becoming an Instructor is a great step to leveling-up your own technical skills and helps you to become a more effective technical communicator.
 
-Read more about our Instructors on [The Carpentries website](/community/instructors/). Check out our resources for Instructors in our [Handbook]({{< param handbook_url >}}/handbooks/instructors.html).
+ Check out our resources for Instructors in our [Handbook]({{< param handbook_url >}}/handbooks/instructors.html).
 
 This page lists Instructors who have consented to appear on our website. If you are an Instructor who is not listed here but would like to be, please [update your profile in AMY (our internal database)]({{< param amy_base >}}) and agree to make your profile public. Log in with GitHub and save your changes. If you have difficulty logging in, please [email us](mailto:{{< param team_email >}}). 
 


### PR DESCRIPTION
removed the verbiage about learning more of Instructors

Please delete this line and the text below before submitting your contribution.

