### PR TITLE
Use oxford comma in footer text

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,10 +1,10 @@
 # General text 
 #############################################
-description: The Carpentries is a registered 501(c)3 non-profit organisation based in Delaware, USA. We are a global community teaching foundational computational and data science skills to researchers in academia, industry and government.
+description: The Carpentries is a registered 501(c)3 non-profit organisation based in Delaware, USA. We are a global community teaching foundational computational and data science skills to researchers in academia, industry, and government.
 images:
 - thecarpentries-opengraph.png
 title: The Carpentries
-footer_overview_text: "The Carpentries is a registered 501(c)3 non-profit organisation based in Delaware, USA. We are a global community teaching foundational computational and data science skills to researchers in academia, industry and government."
+footer_overview_text: "The Carpentries is a registered 501(c)3 non-profit organisation based in Delaware, USA. We are a global community teaching foundational computational and data science skills to researchers in academia, industry, and government."
 
 
 # Logos


### PR DESCRIPTION
Our [style guide](https://docs.carpentries.org/resources/communications/style-guide.html#oxford-comma) notes that the Oxford comma is preferred.
