### PR TITLE
add info and pricing for GenAI in Workshops

### DIFF
--- a/content/instructor-training/_index.md
+++ b/content/instructor-training/_index.md
@@ -63,6 +63,14 @@ The Carpentries workshops are taught by trained and certified volunteer Instruct
 
 {{< accessibility >}}
 
+## GenAI in Workshops Bonus Module
+This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners.
+Referring to the foundational principles of Instructor Training, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
+The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
+
+Previous participation in Instructor Training or [Learner-Centered Teaching](/learner-centered-teaching) is a prerequisite for this bonus module.
+Bonus module sessions take place separately from Instructor Training events and separate registration is required.
+
 ## Contact Us
 
 Have Questions? Please contact our team at [{{< param instructor_training_email >}}](mailto:{{< param instructor_training_email >}}).

--- a/content/instructor-training/_index.md
+++ b/content/instructor-training/_index.md
@@ -68,7 +68,7 @@ This standalone, one-day training bonus module was developed in response to the 
 Referring to the foundational principles of Instructor Training, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
 The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
 
-Previous participation in Instructor Training or [Learner-Centered Teaching](/learner-centered-teaching) is a prerequisite for this bonus module.
+Previous participation in [Instructor Training](/instructor-training/) or [Learner-Centered Teaching](/learner-centered-teaching) is a prerequisite for this bonus module.
 Bonus module sessions take place separately from Instructor Training events and separate registration is required.
 
 ## Contact Us

--- a/content/learner-centered-teaching/_index.md
+++ b/content/learner-centered-teaching/_index.md
@@ -67,6 +67,14 @@ Visit our [calendar](https://carpentries.github.io/instructor-training-lct/train
 
 {{< accessibility >}}
 
+## GenAI in Workshops Bonus Module
+This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners.
+Referring to the principles discussed in Learner-Centered Teaching, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
+The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
+
+Previous participation in Learner-Centered Teaching or [Instructor Training](/instructor-training) is a prerequisite for this bonus module.
+Bonus module sessions take place separately from Learner-Centered Teaching events and separate registration is required.
+
 ## Contact Us
 
 Have Questions? Please contact our team at [{{< param team_email >}}](mailto:{{< param team_email >}}).

--- a/content/support/pricing.md
+++ b/content/support/pricing.md
@@ -41,7 +41,7 @@ Available service options include:
 
 - one (1) workshop using one of our data science or computational skills curricula, or
 - two (2) seats in a certification program (Instructor Training or Collaborative Lesson Development Training), or
-- four (4) seats in our Learner-Centered Teaching program, or
+- four (4) seats in a one-day professional development course (Learner-Centered Teaching or GenAI in Workshops), or
 - sixteen (16) seats in one of our short-format professional development courses, or
 - any fractional combination of the above.
 
@@ -74,6 +74,7 @@ Partner organisations can add services to their existing Partnership package at 
 | **Certification Programs** | **Instructor Training** <br> An interactive introduction to the fundamentals of educational psychology and evidence-based teaching practices. For more information, visit our [Instructor Training page](/instructor-training/). | Two days | $1,600 / seat | $1,200 / seat |
 |                            | **Collaborative Lesson Development Training** <br> Teaches essential skills and good practices for designing and developing a lesson as an open source project. For more information, visit our [Collaborative Lesson Development Training page](/lesson-development/). | Two days | $1,600 / seat | $1,200 / seat |
 | **Professional Development Courses** | **Learner-Centered Teaching** <br> Equips participants with the strategies and tools necessary to use effective, hands-on teaching practices in short-format trainings. For more information, visit our [Learner-Centered Teaching page](/learner-centered-teaching).| One day | $800 / seat | $600 / seat |
+|                                      | **GenAI in Workshops** <br> A supplement to Instructor Training and Learner-Centered Teaching that empowers instructors to account for learners' use of generative AI chatbot tools in their workshops. For more information, visit our [Instructor Training page](/instructor-training/#genai-in-workshops-bonus-module).| One day | $800 / seat | $600 / seat |
 |                                      | **Short-Format Professional Development** <br> Learning sessions on specific competencies, knowledge, or skills. For more information, visit our [Professional Development page](/professional-development/). | 2-3 hours | $200 / seat | $150 / seat |
 {{< /table >}}
 


### PR DESCRIPTION
* Adds information about the bonus module to the info pages for IT and LCT.
* Adds a row for the bonus module to the pricing table, and mentions it as another service option alongside LCT.