### PR TITLE
GenAI page

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -164,7 +164,7 @@ main:
   weight: 50
 - identifier: genai-bonus
   name: GenAI in Workshops Bonus Module
-  url: "/instructor-training/#genai-in-workshops-bonus-module"
+  url: "/genai"
   parent: learn
   weight: 55
 - identifier: trainer-training

--- a/content/genai/_index.md
+++ b/content/genai/_index.md
@@ -1,0 +1,15 @@
+---
+title: Generative AI in Workshops Bonus Module
+layout: single
+---
+
+## Overview
+
+This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners.
+
+Referring to the principles discussed in Learner-Centered Teaching and Instructor Training, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
+The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
+
+Previous participation in [Learner-Centered Teaching](/learner-centered-teaching) or [Instructor Training](/instructor-training) is a prerequisite for this bonus module. Bonus module sessions take place separately from other training events.  Review information about [pricing](/support/pricing) and [registration](https://pretix.carpentries.org/training/genai/).
+
+Review the [GenAI in Workshops: Instructor Training Bonus Module curriculum here](https://carpentries.github.io/instructor-training-genai/).

--- a/content/instructor-training/_index.md
+++ b/content/instructor-training/_index.md
@@ -64,12 +64,8 @@ The Carpentries workshops are taught by trained and certified [volunteer Instruc
 {{< accessibility >}}
 
 ## GenAI in Workshops Bonus Module
-This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners.
-Referring to the foundational principles of Instructor Training, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
-The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
+This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners. [Read more about the curriculum and how to register here](/genai).
 
-Previous participation in [Instructor Training](/instructor-training/) or [Learner-Centered Teaching](/learner-centered-teaching) is a prerequisite for this bonus module.
-Bonus module sessions take place separately from Instructor Training events and separate registration is required.
 
 ## Contact Us
 

--- a/content/learner-centered-teaching/_index.md
+++ b/content/learner-centered-teaching/_index.md
@@ -68,12 +68,8 @@ Visit our [calendar](https://carpentries.github.io/instructor-training-lct/train
 {{< accessibility >}}
 
 ## GenAI in Workshops Bonus Module
-This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners.
-Referring to the principles discussed in Learner-Centered Teaching, participants are led by expert Trainers through a series of exercises and discussions to explore effective strategies to maximise learning in the presence of AI tools.
-The bonus module is perfect for anyone preparing to deliver workshops and other training to novice learners who are making regular use of chatbot tools like ChatGPT, Claude and Gemini.
+This standalone, one-day training bonus module was developed in response to the growing numbers of reports we have received from Instructors who have observed frequent chatbot use among their learners. [Read more about the curriculum and how to register here](/genai).
 
-Previous participation in Learner-Centered Teaching or [Instructor Training](/instructor-training) is a prerequisite for this bonus module.
-Bonus module sessions take place separately from Learner-Centered Teaching events and separate registration is required.
 
 ## Contact Us
 


### PR DESCRIPTION
Addresses #695 with the following:

* Create a standalone GenAI page based on the duplicated language that was on the LCT and IT pages ([preview](https://deploy-preview-698--carpentries-website.netlify.app/genai/))
* Reduce the language on the LCT page ([preview](https://deploy-preview-698--carpentries-website.netlify.app/learner-centered-teaching/#genai-in-workshops-bonus-module)) and IT page ([preview](https://deploy-preview-698--carpentries-website.netlify.app/instructor-training/#genai-in-workshops-bonus-module)) to one line directing to the new page 
* Updates the link the top Learn menu to the new page instead of the section within IT
 